### PR TITLE
Change rodio version to most recent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 iced = { version = "0.13.1", features = ["tokio"] }
-rodio = "0.20.1"
+rodio = { git = "https://github.com/RustAudio/rodio.git", features = ["symphonia", "symphonia-mp3"] }
 tokio = { version = "1.44.0", features = ["full"] }

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -11,6 +11,7 @@ pub enum Audio {
     Previous,
     Next,
     RandomNextTrack,
+    Duration,
     SliderPositionChanged(f32),
     UpdatePlaybackPosition(f32),
     PlaybackTick,
@@ -21,4 +22,5 @@ pub enum Audio {
 pub enum File {
     Load,
     Display,
+    Duration,
 }

--- a/src/app/state/audio.rs
+++ b/src/app/state/audio.rs
@@ -16,12 +16,13 @@ use iced::widget::{button, column, container, progress_bar, row, slider, text};
 use iced::widget::{Button, Column, Container};
 use iced::{Subscription, Renderer, Theme, Element, Task, Fill};
 
-use rodio::{Decoder, OutputStream, Sink};
+use rodio::{Decoder, OutputStream, Sink, Source};
 
 #[derive(Default)]
 pub struct AudioState {
     volume: f32,
-    current_position: f32,
+    pub song_length: Option<Duration>, 
+    pub current_pos: f32,
     playback_sink: Option<Sink>,
     _audio_stream: Option<OutputStream>,
 }
@@ -30,7 +31,8 @@ impl AudioState {
     pub fn new() -> Self {
         Self {
             volume: 0.0,
-            current_position: 0.0,
+            song_length: None,
+            current_pos: 0.0,
             playback_sink: None,
             _audio_stream: None,
         }
@@ -39,7 +41,7 @@ impl AudioState {
     pub fn update(&mut self, message: Audio) -> Task<Audio> {
         match message {
             Audio::Load => {
-                self.load_audio("C:/Users/webbs/programming/cs/rust/musicplayer/src/app/state/song.mp3");
+                self.load_audio("C:/Users/webbs/programming/cs/rust/musicplayer/src/app/state/song2.flac");
                 Task::none()
             },
             Audio::TogglePlayPause => {
@@ -52,6 +54,19 @@ impl AudioState {
                 }
                 Task::none()
             },
+            Audio::PlaybackTick => {
+                self.update_playback_position();
+                Task::none()
+            },
+            Audio::Duration => {
+                
+
+                
+                dbg!("{}", self.song_length);
+                Task::none()
+            },
+
+
             _ => {Task::none()},
         }
     }
@@ -70,6 +85,8 @@ impl AudioState {
             let sink = Sink::try_new(&stream_handle).unwrap();
             let file = BufReader::new(fs::File::open(file_path).unwrap());
             let source = Decoder::new(file).unwrap();
+            dbg!(source.current_frame_len());
+
 
             sink.append(source);
             sink.set_volume(0.2);
@@ -77,12 +94,18 @@ impl AudioState {
             self._audio_stream = Some(stream);
             self.playback_sink = Some(sink);
         }
+        
     }
 
     pub fn update_playback_position(&mut self) {
         if let Some(sink) = &self.playback_sink {
-            self.current_position = sink.get_pos().as_secs_f32();
+            self.current_pos = sink.get_pos().as_secs_f32();
         }
+    }
+
+    pub fn song_duration(&self) -> f32 {
+        self.song_length.map(|d| d.as_secs_f32())
+            .unwrap_or(0.0)
     }
 
     pub fn song_progress(&self) -> u64 {

--- a/src/app/state/files.rs
+++ b/src/app/state/files.rs
@@ -25,6 +25,9 @@ impl FileState {
                 //TODO:
                 Task::none()
             },
+            File::Duration => {
+                Task::none()
+            },
             _ => {Task::none()},
         }
     }

--- a/src/app/view/view.rs
+++ b/src/app/view/view.rs
@@ -1,5 +1,5 @@
 use iced::{Element};
-use iced::widget::{button, Column, Row, Button};
+use iced::widget::{button, text, Column, Row, Button, progress_bar};
 use crate::app::state::audio::AudioState; // Reference the state controller
 use crate::app::message::Audio;
 use crate::app::view::playlist;
@@ -19,8 +19,9 @@ impl AudioState {
     pub fn view(&self) -> Element<Audio> {
         Column::new()
             .push(Self::playback_controls())
+            .push(progress_bar(0.0..=1.0, self.current_pos))
+            .push(button("Song duration").on_press(Audio::Duration))
             .into()
-
     }
 
 
@@ -32,5 +33,8 @@ impl AudioState {
             });
         playback_controls.into()
     }
+
+
+
 
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod app;
-use iced::{Theme, Element, Task};
+use iced::{Theme, Element, Task, Subscription};
 use iced::widget::{button, Column};
 
 
@@ -13,7 +13,7 @@ fn main() -> iced::Result {
         Controller::update,
         Controller::view,
     )
-    //.subscription(AudioState::subscription)
+    .subscription(Controller::subscription)
     .resizable(false)
     .theme(|_| Theme::Light)
     .run()
@@ -46,10 +46,25 @@ impl Controller {
                 println!("Test works");
                 Task::none()
             },
+            Audio::PlaybackTick => {
+                self.audio.update_playback_position();
+                Task::none()
+            },
+            Audio::Duration => {
+                dbg!(self.audio.song_duration());
+                dbg!("in main::Duration");
+                Task::none()
+
+            },
+
             _ => {
                 self.audio.update(message)
             },
         }
+    }
+
+    pub fn subscription(&self) -> Subscription<Audio> {
+        self.audio.subscription()
     }
 
 


### PR DESCRIPTION
Turns out crate version is only updated on a "release" from github, so much needed features that were released last week are only available from the git repo